### PR TITLE
Minor fixes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Привет, это проэкт Slovs
+# Slovs
 
-## Description
-
-This application is designed to memorize English words
+This application is designed to memorize English words.
 
 ## Usage
 
-1. Add dictionary-file to your working directory (name_file.json):
+1. Add dictionary-file to your working directory `name_file.json`:
 ```
 {
 	"in case of": "в случае",
@@ -16,5 +14,5 @@ This application is designed to memorize English words
 ```
 
 2. Create an environment variable `export SLOVSFILE='name_file.json'` containing the path to dictionary-file.
-3. To run the program, enter `./main.py -f name_file.json` into the console.
+3. To run the program, enter `python3 main.py -f name_file.json` into the console.
  


### PR DESCRIPTION
Немного подчистил ридми от лишних слов.

Так же заменил последний пункт инструкции запуска приложения:

`./main.py -f name_file.json` -> `python3 main.py -f name_file.json`

Так как не все знают что такое chmod и как сделать программу запускаемой. Поэтому сделал более универсальную команду.